### PR TITLE
chore(deps): drop redundant dependencies Django and django-auditlog

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,11 @@ authors = [{ name = "Matthias Schlögl" }]
 requires-python = "~=3.13.0"
 license = "MIT"
 dependencies = [
-    "Django~=5.2",
     "apis-core-rdf==0.63.1",
     "apis-acdhch-default-settings==2.18.0",
     "django-interval>=0.5.1,<0.6",
     "django-json-editor-field>=0.4.2,<0.5",
     "psycopg[binary]~=3.0",
-    "django-auditlog==3.4.1",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
They are dependencies of other dependencies anyway
