### PR TITLE
chore(deps): drop non standard dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["ruff>=0.11.8,<0.12", "pyright>=1.1.400,<2", "debugpy>=1.8.14,<2"]
+dev = ["ruff>=0.11.8,<0.12"]
 
 [tool.hatch.build.targets.sdist]
 include = ["apis_ontology"]


### PR DESCRIPTION
They only lead to more dependabot PRs
